### PR TITLE
Fix billing address output in default template

### DIFF
--- a/core/components/commerce_packingslip/templates/packingslip/standard.twig
+++ b/core/components/commerce_packingslip/templates/packingslip/standard.twig
@@ -111,7 +111,7 @@
         </td>
         <td>
             <h3>{{ lex('commerce.billing_address') }}</h3>
-            {{ shipping|format_address }}
+            {{ billing|format_address }}
         </td>
     </tr>
 </table>


### PR DESCRIPTION
Billing address was outputting the shipping address in the default template.